### PR TITLE
Remplace edit/main par blob/master

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,13 +97,13 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:
-            'https://github.com/Les-Moddeurs-Francais/Forge-Doc/edit/main',
+            'https://github.com/Les-Moddeurs-Francais/Forge-Doc/blob/master',
         },
         blog: {
           showReadingTime: false,
           // Please change this to your repo.
           editUrl:
-            'https://github.com/Les-Moddeurs-Francais/Forge-Doc/edit/main',
+            'https://github.com/Les-Moddeurs-Francais/Forge-Doc/blob/master',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,13 +97,13 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:
-            'https://github.com/Les-Moddeurs-Francais/Forge-Doc/blob/master',
+            'https://github.com/Les-Moddeurs-Francais/Forge-Doc/edit/master',
         },
         blog: {
           showReadingTime: false,
           // Please change this to your repo.
           editUrl:
-            'https://github.com/Les-Moddeurs-Francais/Forge-Doc/blob/master',
+            'https://github.com/Les-Moddeurs-Francais/Forge-Doc/edit/master',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Par défaut,  l'utilisateur lamba ne peut pas accéder a la page d'édition, sauf si celui-ci est membre de l'organisation, donc toute personne cliquant sur le bouton ```Éditer sur github``` se retrouve devant une page 404.

![Screenshot_20210816-185712_Chrome](https://user-images.githubusercontent.com/67557705/129601436-824cbab5-c5a2-42f3-a43b-c2c7ea6691a5.jpg)

Cette modification, permet d'afficher le fichier comme on le regarde sur github, et si l'utilisateur veut le modifier, il lui sera demandé de fork le projet ! 
(Je trouve cette solution meilleur que de donner l'accès au répertoire a tout le monde 🙃)